### PR TITLE
Configuration reworked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-5
+            - g++-7
             - cmake
             - make
             - libcurl4-gnutls-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
             - cmake
             - make
             - libcurl4-gnutls-dev
-            # - gpsd
+            - libcppunit
             - libqgpsmm-dev
             - libgps-dev
             - cppcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
             - cmake
             - make
             - libcurl4-gnutls-dev
-            - libcppunit
+            - libcppunit-1.13
             - libqgpsmm-dev
             - libgps-dev
             - cppcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ before_install:
 script:
      - mkdir -p build
      - cd build
-     - cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CXX_FLAGS} -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON .. 
+     - cmake ${CMAKE_OPTIONS} -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON .. 
      - make
      - ./rtdata_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: bionic
       compiler: gcc
       sudo: true
       addons:
@@ -11,17 +11,16 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
+            - g++-5
             - cmake
             - make
             - libcurl4-gnutls-dev
-            - libcppunit-1.13
             - libqgpsmm-dev
             - libgps-dev
             - cppcheck
             - libcppunit-dev
       env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
 before_install:
     - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: bionic
+      dist: xenial
       compiler: gcc
       sudo: true
       addons:
@@ -11,7 +11,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
+            - g++-5
             - cmake
             - make
             - libcurl4-gnutls-dev
@@ -20,7 +20,7 @@ matrix:
             - cppcheck
             - libcppunit-dev
       env:
-         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
 before_install:
     - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
 before_install:
     - eval "${MATRIX_EVAL}"
     - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
-    - wget https://github.com/CosmicResearch/g3log/releases/download/1.3.3/g3log-Linux-x86.deb
-    - sudo dpkg -i g3log-Linux-x86.deb
 
 script:
      - mkdir -p build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ IF(BUILD_TESTS)
             rtdata
             pthread
         )
+        IF(g3logger_FOUND AND WITH_LOGGING)
+            target_link_libraries(rtdata_test g3logger)
+        ENDIF()
     ENDIF()
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ project(rtdata)
 set (rtdata_VERSION_MAJOR 0)
 set (rtdata_VERSION_MINOR 1)
 
-SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage -lcppunit")
-SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage -lcppunit")
+SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 
 set(JSON_BuildTests OFF CACHE INTERNAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ project(rtdata)
 set (rtdata_VERSION_MAJOR 0)
 set (rtdata_VERSION_MINOR 1)
 
-SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
-SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage -lcppunit")
+SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage -lcppunit")
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 
 set(JSON_BuildTests OFF CACHE INTERNAL "")

--- a/src/Data.h
+++ b/src/Data.h
@@ -99,7 +99,7 @@ public:
      * @param object The resulting SerializedObject where the data must be saved.
      */
     virtual void serialize(SerializedObject* object) override {
-        object->put("timestamp", (unsigned int) time.toNanos());
+        object->put("timestamp", time.toNanos());
         object->put("origin", origin);
     }
 
@@ -108,7 +108,7 @@ public:
      * @param object The SerializedObject to load the data from.
      */
     virtual void deserialize(SerializedObject* object) override {
-        time = Timestamp(object->getUInt("timestamp"));
+        time = Timestamp(object->getLongInt("timestamp"));
         origin = object->getString("origin");
     }
 

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -57,11 +57,10 @@ public:
      * Constructor with configuration object
      * @param config The node containing the configuration for this sensor
      */
-    explicit Sensor(std::shared_ptr<Configuration> config) : 
-        config(config),
-        name(config->at("name")->get<std::string>()),
-        topic(config->at("topic")->get<std::string>()),
-        sampling_rate(config->at("sampling_rate")->get<uint64_t>()),
+    explicit Sensor(Configuration& config) : 
+        name(config["name"].get<std::string>()),
+        topic(config["topic"].get<std::string>()),
+        sampling_rate(config["sampling_rate"].get<uint64_t>()),
         started(false),
         stopped(false) {
 
@@ -174,8 +173,6 @@ protected:
      * Each interval of `sampling_rate` nanoseconds the sensor will be read.
      */
     uint64_t sampling_rate;
-
-    std::shared_ptr<Configuration> config;
 
     /**
      * Internal thread-safe queue where the read data is stored. 

--- a/src/sensors/AnalogSensor.h
+++ b/src/sensors/AnalogSensor.h
@@ -60,14 +60,14 @@ public:
      * Constructor with Configuration object
      * @param config The configuration node for this sensor
      */
-    explicit AnalogSensor(std::shared_ptr<Configuration> config) : 
+    explicit AnalogSensor(Configuration& config) : 
         Sensor(config),
-        zero_value(config->at("zero")->get<double>()),
-        span_value(config->at("span")->get<double>()),
-        scale(config->at("span")->get<double>()),
-        quantization_bits(config->at("quantization_bits")->get<uint64_t>()),
-        zero_voltage(config->at("zero_voltage")->get<int64_t>()),
-        span_voltage(config->at("span_voltage")->get<int64_t>()) {
+        zero_value(config["zero"].get<double>()),
+        span_value(config["span"].get<double>()),
+        scale(config["span"].get<double>()),
+        quantization_bits(config["quantization_bits"].get<uint64_t>()),
+        zero_voltage(config["zero_voltage"].get<int64_t>()),
+        span_voltage(config["span_voltage"].get<int64_t>()) {
             zero = (double)(1 << quantization_bits) * (zero_value - zero_voltage) / span_voltage;
             span = (double)(1 << quantization_bits) * (span_value) / span_voltage;
     }

--- a/src/sensors/GPSSensor.h
+++ b/src/sensors/GPSSensor.h
@@ -59,8 +59,8 @@ public:
      * Constructor with a Configuration object
      * @param config The node containing the configuration for this sensor
      */
-    explicit GPSSensor(std::shared_ptr<Configuration> config) : Sensor(config), 
-        host(config->at("host")->get<std::string>()), port(config->at("port")->get<std::string>()), gps(host.c_str(), port.c_str()) {
+    explicit GPSSensor(Configuration& config) : Sensor(config), 
+        host(config["host"].get<std::string>()), port(config["port"].get<std::string>()), gps(host.c_str(), port.c_str()) {
 
     }
 

--- a/src/serialization/ByteObject.h
+++ b/src/serialization/ByteObject.h
@@ -75,6 +75,10 @@ public:
         _put_string(key, value);
     }
 
+    virtual void put(const std::string& key, uint64_t value) {
+        _put<uint64_t>(key, value);
+    }
+
     /**
      * 'Get' methods to deserialize objects
      * @param key The key of the value to be deserialized. This parameter is ignored.
@@ -103,6 +107,10 @@ public:
 
     virtual std::string getString(const std::string& key) {
         return _get_string(key);
+    }
+
+    virtual uint64_t getLongInt(const std::string& key) {
+        return _get<uint64_t>(key);
     }
 
     /**

--- a/src/serialization/JSONObject.h
+++ b/src/serialization/JSONObject.h
@@ -72,6 +72,10 @@ public:
         _put<std::string>(key, value);
     }
 
+    virtual void put(const std::string& key, uint64_t value) {
+        _put<uint64_t>(key, value);
+    }
+
     /**
      * 'Get' methods to deserialize objects
      * @param key The key of the value to be deserialized. This parameter is ignored.
@@ -100,6 +104,10 @@ public:
 
     virtual std::string getString(const std::string& key) {
         return _get<std::string>(key);
+    }
+
+    virtual uint64_t getLongInt(const std::string& key) {
+        return _get<uint64_t>(key);
     }
 
     /**

--- a/src/serialization/SQLiteObject.h
+++ b/src/serialization/SQLiteObject.h
@@ -73,6 +73,10 @@ public:
         _put(key, escaped_value, Type::STRING);
     }
 
+    virtual void put(const std::string& key, uint64_t value) {
+        _put(key, value, Type::LONGINT);
+    }
+
     /**
      * 'Get' methods to deserialize objects
      * @param key The key of the value to be deserialized. This parameter is ignored.
@@ -106,6 +110,10 @@ public:
             content.erase( content.end() - 1 );
         }
         return content;
+    }
+
+    virtual uint64_t getLongInt(const std::string& key) {
+        return contents[key]->get<uint64_t>();
     }
 
     /**
@@ -191,7 +199,7 @@ public:
 private:
 
     enum Type {
-        INT, UINT, FLOAT, DOUBLE, BOOL, STRING
+        INT, UINT, FLOAT, DOUBLE, BOOL, STRING, LONGINT
     };
 
     template <typename T>
@@ -220,6 +228,9 @@ private:
                 break;
             case STRING:
                 insert.bind(bind_column_name, contents[column]->get<std::string>());
+                break;
+            case LONGINT:
+                insert.bind(bind_column_name, (long long int)contents[column]->get<uint64_t>());
                 break;
         }
     }

--- a/src/serialization/SerializedObject.h
+++ b/src/serialization/SerializedObject.h
@@ -50,6 +50,8 @@ public:
 
     virtual void put(const std::string& key, std::string value) = 0;
 
+    virtual void put(const std::string& key, uint64_t value) = 0;
+
     /**
      * 'Get' methods to deserialize objects
      * @param key The key of the value to be deserialized. Could be ignored by the implementation.
@@ -67,6 +69,8 @@ public:
     virtual bool getBool(const std::string& key) = 0;
 
     virtual std::string getString(const std::string& key) = 0;
+
+    virtual uint64_t getLongInt(const std::string& key) = 0;
 
     /**
      * Obtain the bytes of the serialized object

--- a/src/utils/Configuration.cpp
+++ b/src/utils/Configuration.cpp
@@ -18,13 +18,41 @@
 
 #include "Configuration.h"
 
-std::shared_ptr<Configuration> Configuration::at(const std::string& property) {
+Configuration& Configuration::at(const std::string& property) {
+    throw std::runtime_error("Operation not supported on a leaf node");
+}
+
+Configuration& Configuration::at(const int index) {
+    throw std::runtime_error("Operation not supported on a leaf node");
+}
+
+Configuration& ConfigurationTreeNode::at(const std::string& property) {
     if (childs.find(property) == childs.end()) {
         load_from_implementation(property);
     }
-    return childs[property];
+    return *childs[property];
 }
 
-std::shared_ptr<Configuration> Configuration::operator[](const std::string &property) {
+Configuration& ConfigurationArrayNode::at(const int index) {
+    if (!loaded) {
+        load_from_implementation();
+        loaded = true;
+    }
+    return *childs[index];
+}
+
+Configuration& Configuration::operator[](const std::string &property) {
     return this->at(property);
+}
+
+Configuration& Configuration::operator[](const int index) {
+    return this->at(index);
+}
+
+Configuration& ConfigurationTreeNode::at(const int index) {
+    throw std::runtime_error("Operation not supported on a tree node");
+}
+
+Configuration& ConfigurationArrayNode::at(const std::string& property) {
+    throw std::runtime_error("Operation not supported on an array node");
 }

--- a/src/utils/JSONConfiguration.cpp
+++ b/src/utils/JSONConfiguration.cpp
@@ -19,9 +19,9 @@
 #include "JSONConfiguration.h"
 #include "Log.h"
 
-void JSONConfiguration::load_from_implementation(const std::string& property) {
+void JSONObjectConfiguration::load_from_implementation(const std::string& property) {
     if (file.find(property) != file.end()) {
-        if (not file[property].is_object() and not file[property].is_array()) {
+        if (!file[property].is_object() && !file[property].is_array()) {
             std::shared_ptr<Any> new_content;
             if (file[property].is_boolean()) {
                 new_content = Any::create_any<bool>(file[property].get<bool>());
@@ -38,13 +38,57 @@ void JSONConfiguration::load_from_implementation(const std::string& property) {
             else if (file[property].is_number_integer()) {
                 new_content = Any::create_any<int64_t>(file[property].get<int64_t>());
             }
-            childs[property] = std::make_shared<JSONConfiguration>(new_content);
+            childs[property] = std::make_shared<Configuration>(new_content);
+        }
+        else if (file[property].is_object()){
+            childs[property] = std::make_shared<JSONObjectConfiguration>(file[property]);
+        }
+        else if (file[property].is_array()) {
+            childs[property] = std::make_shared<JSONArrayConfiguration>(file[property]);
         }
         else {
-            childs[property] = std::make_shared<JSONConfiguration>(file[property]);
+            childs[property] = std::make_shared<Configuration>();
         }
     }
     else {
-        childs[property] = std::make_shared<JSONConfiguration>();
+        childs[property] = std::make_shared<Configuration>();
+    }
+}
+
+void JSONArrayConfiguration::load_from_implementation() {
+    childs.resize(file.size());
+    for (int i = 0; i < file.size(); ++i) {
+        load_child(i);
+    }
+}
+
+void JSONArrayConfiguration::load_child(const int index) {
+    if (!file[index].is_object() && !file[index].is_array()) {
+        std::shared_ptr<Any> new_content;
+        if (file[index].is_boolean()) {
+            new_content = Any::create_any<bool>(file[index].get<bool>());
+        }
+        else if (file[index].is_string()) {
+            new_content = Any::create_any<std::string>(file[index].get<std::string>());
+        }
+        else if (file[index].is_number_float()) {
+            new_content = Any::create_any<double>(file[index].get<double>());
+        }
+        else if (file[index].is_number_unsigned()) {
+            new_content = Any::create_any<uint64_t>(file[index].get<uint64_t>());
+        }
+        else if (file[index].is_number_integer()) {
+            new_content = Any::create_any<int64_t>(file[index].get<int64_t>());
+        }
+        childs[index] = std::make_shared<Configuration>(new_content);
+    }
+    else if (file[index].is_object()){
+        childs[index] = std::make_shared<JSONObjectConfiguration>(file[index]);
+    }
+    else if (file[index].is_array()) {
+        childs[index] = std::make_shared<JSONArrayConfiguration>(file[index]);
+    }
+    else {
+        childs[index] = std::make_shared<Configuration>();
     }
 }

--- a/src/utils/JSONConfiguration.h
+++ b/src/utils/JSONConfiguration.h
@@ -25,10 +25,11 @@
 
 /**
  * A class that represents a configuration file with a tree-like structure, loaded from a JSON file.
- * Each node of the tree represents either a property (leaf) or another tree.
+ * This class can also represent a JSON object in a JSON document.
+ * Each node of the tree represents either a property (leaf), an array or another tree.
  * The configuration properties are not loaded until they are acessed for the first time (lazy initialization).
  */
-class JSONConfiguration : public Configuration {
+class JSONObjectConfiguration : public ConfigurationTreeNode {
 
 public:
 
@@ -37,7 +38,7 @@ public:
      * Loads and parses the passed filename as a JSON file.
      * @param file The filename of a JSON file.
      */
-    explicit JSONConfiguration(std::string file) : Configuration() {
+    explicit JSONObjectConfiguration(std::string file) : ConfigurationTreeNode() {
         std::ifstream i(file);
         this->file = nlohmann::json::parse(i);
     }
@@ -46,14 +47,14 @@ public:
      * Constructor with a JSON object
      * @param file A JSON object
      */
-    explicit JSONConfiguration(const nlohmann::json& file) : file(file) {
+    explicit JSONObjectConfiguration(const nlohmann::json& file) : file(file), ConfigurationTreeNode() {
 
     }
 
     /**
      * Default constructor
      */
-    JSONConfiguration() : Configuration() {
+    JSONObjectConfiguration() : ConfigurationTreeNode() {
 
     }
 
@@ -61,7 +62,7 @@ public:
      * Constructor to build a leaf
      * @param content The content of the leaf
      */
-    explicit JSONConfiguration(std::shared_ptr<Any> content) : Configuration(content) {
+    explicit JSONObjectConfiguration(std::shared_ptr<Any> content) : ConfigurationTreeNode(content) {
 
     }
 
@@ -78,3 +79,61 @@ private:
     nlohmann::json file;
 
 };
+
+/**
+ * A class that represents a configuration array, loaded from a JSON file.
+ * All the array is loaded at once.
+ */
+class JSONArrayConfiguration : public ConfigurationArrayNode {
+
+public:
+
+    /**
+     * Constructor with filename
+     * Loads and parses the passed filename as a JSON file.
+     * @param file The filename of a JSON file.
+     */
+    explicit JSONArrayConfiguration(std::string file) : ConfigurationArrayNode() {
+        std::ifstream i(file);
+        this->file = nlohmann::json::parse(i);
+    }
+
+    /**
+     * Constructor with a JSON object
+     * @param file A JSON object
+     */
+    explicit JSONArrayConfiguration(const nlohmann::json& file) : file(file), ConfigurationArrayNode() {
+
+    }
+
+    /**
+     * Default constructor
+     */
+    JSONArrayConfiguration() : ConfigurationArrayNode() {
+
+    }
+
+    /**
+     * Constructor to build a leaf
+     * @param content The content of the leaf
+     */
+    explicit JSONArrayConfiguration(std::shared_ptr<Any> content) : ConfigurationArrayNode(content) {
+
+    }
+
+protected:
+
+    /**
+     * Load the array from the JSON file
+     */
+    virtual void load_from_implementation();
+
+private:
+
+    inline void load_child(const int index);
+
+    nlohmann::json file;
+
+};
+
+using JSONConfiguration = JSONObjectConfiguration;

--- a/test/JSONConfigurationTest.cpp
+++ b/test/JSONConfigurationTest.cpp
@@ -23,45 +23,46 @@
 #include "JSONConfigurationTest.h"
 
 void JSONConfigurationTest::getBoolTest() {
-    bool test = config["bool_true"]->get<bool>();
+    bool test = config["bool_true"].get<bool>();
     CPPUNIT_ASSERT(test);
 }
 
 void JSONConfigurationTest::getStringTest() {
-    std::string test = config["string_test"]->get<std::string>();
+    std::string test = config["string_test"].get<std::string>();
     CPPUNIT_ASSERT(test == std::string("test"));
 }
 
 void JSONConfigurationTest::getFloatTest() {
-    double test = config["float_three"]->get<double>();
+    double test = config["float_three"].get<double>();
     // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
     bool almost_equal = std::abs(test - 3.0) <= std::numeric_limits<double>::epsilon() * std::abs(test + 3.0) * 2 || std::abs(test - 3.0) < std::numeric_limits<double>::min();
     CPPUNIT_ASSERT(almost_equal);
 }
 
 void JSONConfigurationTest::getIntTest() {
-    int64_t test = config["int_minus_three"]->get<int64_t>();
+    int64_t test = config["int_minus_three"].get<int64_t>();
     CPPUNIT_ASSERT(test == -3);
 }
 
 void JSONConfigurationTest::getUIntTest() {
-    uint64_t test = config["uint_three"]->get<uint64_t>();
+    uint64_t test = config["uint_three"].get<uint64_t>();
     CPPUNIT_ASSERT(test == 3);
 }
 
 void JSONConfigurationTest::getArrayTest() {
-    std::vector<int64_t> test = config["array"]->get<std::vector<int64_t>>();
-    CPPUNIT_ASSERT(test[0] == 3);
-    CPPUNIT_ASSERT(test[1] == 4);
+    int64_t test0 = config["array"][0].get<int64_t>();
+    int64_t test1 = config["array"][1].get<int64_t>();
+    CPPUNIT_ASSERT(test0 == 3);
+    CPPUNIT_ASSERT(test1 == 4);
 }
 
 void JSONConfigurationTest::getNestedConfig() {
-    int64_t test = config["object"]->at("int_three")->get<int64_t>();
+    int64_t test = config["object"]["int_three"].get<int64_t>();
     CPPUNIT_ASSERT(test == 3);
 }
 
 void JSONConfigurationTest::setInt() {
-    config["object"]->at("int_three")->set((int64_t)5);
-    int64_t test = config["object"]->at("int_three")->get<int64_t>();
+    config["object"]["int_three"].set((int64_t)5);
+    int64_t test = config["object"]["int_three"].get<int64_t>();
     CPPUNIT_ASSERT(test == 5);
 }

--- a/test/JSONConfigurationTest.h
+++ b/test/JSONConfigurationTest.h
@@ -29,7 +29,7 @@ class JSONConfigurationTest : public CppUnit::TestFixture {
     CPPUNIT_TEST(getFloatTest);
     CPPUNIT_TEST(getIntTest);
     CPPUNIT_TEST(getUIntTest);
-    //CPPUNIT_TEST(getArrayTest);
+    CPPUNIT_TEST(getArrayTest);
     CPPUNIT_TEST(getNestedConfig);
     CPPUNIT_TEST(setInt);
     CPPUNIT_TEST_SUITE_END();

--- a/test/SensorTest.cpp
+++ b/test/SensorTest.cpp
@@ -23,12 +23,6 @@ const std::string SensorTest::TOPIC = "sensor_topic";
 const uint64_t SensorTest::RATE = 10;
 
 void SensorTest::setUp() {
-    nlohmann::json file = {
-        {"name", NAME},
-        {"topic", TOPIC},
-        {"sampling_rate", RATE}
-    };
-    config = std::make_shared<JSONConfiguration>(file);
     sensor = std::make_shared<SensorStub>();
 }
 
@@ -64,6 +58,12 @@ void SensorTest::stopTest() {
 }
 
 void SensorTest::configTest() {
+    nlohmann::json file = {
+        {"name", NAME},
+        {"topic", TOPIC},
+        {"sampling_rate", RATE}
+    };
+    JSONConfiguration config(file);
     SensorStub sensor(config);
     CPPUNIT_ASSERT(sensor.getName() == NAME);
     CPPUNIT_ASSERT(sensor.getTopic() == TOPIC);

--- a/test/SensorTest.h
+++ b/test/SensorTest.h
@@ -45,7 +45,6 @@ public:
 private:
 
     std::shared_ptr<Sensor> sensor;
-    std::shared_ptr<JSONConfiguration> config;
 
     static const std::string NAME;
     static const std::string TOPIC;

--- a/test/acceptance/Application.cpp
+++ b/test/acceptance/Application.cpp
@@ -26,7 +26,7 @@ SQLiteWriter writer("database.db");
 
 void Application::setup() {
     Log::init();
-    Log::log(INFO, "Acceptance test config started");
+    Log::logMessage(INFO, "Acceptance test config started");
     writer.open();
     std::shared_ptr<Sensor> sensor = std::make_shared<AnalogSensor>(
         "./a.txt", // file
@@ -43,14 +43,15 @@ void Application::setup() {
     manager.addSensor(sensor);
     broker.subscribe("test", std::make_shared<LambdaListener>([](std::string topic, std::shared_ptr<Data> data) {
         std::shared_ptr<AnalogData> analog_data = std::static_pointer_cast<AnalogData>(data);
-        Log::log(DEBUG, "Received data with value %f", analog_data->getValue());
-        Log::log(DEBUG, "Received data with origin %s", data->getOrigin().c_str());
+        Log::logMessage(DEBUG, "Received data with time %llu", (long long unsigned int)analog_data->getTimestamp().toNanos());
+        Log::logMessage(DEBUG, "Received data with value %f", analog_data->getValue());
+        Log::logMessage(DEBUG, "Received data with origin %s", data->getOrigin().c_str());
         writer.write(topic, data);
         writer.flush();
     }));
     broker.start();
     manager.start();
-    Log::log(INFO, "Acceptance test config ended");
+    Log::logMessage(INFO, "Acceptance test config ended");
 }
 
 void Application::loop() {

--- a/test/acceptance2/Application.cpp
+++ b/test/acceptance2/Application.cpp
@@ -34,7 +34,7 @@ void Application::setup() {
     httpWriter.open();
     tcpWriter.open();
     JSONConfiguration config(std::string("config.json"));
-    std::shared_ptr<Sensor> sensor = std::make_shared<GPSSensor>(config.at("sensors")->at("gps"));
+    std::shared_ptr<Sensor> sensor = std::make_shared<GPSSensor>(config["sensors"]["gps"]);
     manager.addSensor(sensor);
     broker.subscribe("test", std::make_shared<LambdaListener>([](std::string topic, std::shared_ptr<Data> data) {
         std::shared_ptr<GPSData> analog_data = std::static_pointer_cast<GPSData>(data);


### PR DESCRIPTION
It's now possible to navigate the configuration tree by using the `[]` operator. This works both for accessing subtrees and arrays/vectors.

This solves issue #2. 