### PR TITLE
Broker and Sensor using real-time policies

### DIFF
--- a/src/Broker.cpp
+++ b/src/Broker.cpp
@@ -22,6 +22,8 @@ void Broker::start() {
     if (started || stopped) {
         throw std::runtime_error("Cannot start already started or stopped Broker");
     }
+    int priority = Thread::getMaxSchedulingPriority(SchedulingPolicy::RT_ROUND_ROBIN) - 2;
+    pool.setSchedulingPolicy(SchedulingPolicy::RT_ROUND_ROBIN, priority);
     this->started = true;
 }
 

--- a/src/Broker.h
+++ b/src/Broker.h
@@ -36,7 +36,8 @@ public:
     /**
      * Default constructor
      */
-    Broker() : started(false), stopped(false) {
+    Broker() : started(false), stopped(false), 
+        pool(std::thread::hardware_concurrency() > 0? std::thread::hardware_concurrency() : 4) {
 
     }
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -62,6 +62,12 @@ private:
 };
 
 template<typename T>
+LogLine& operator<<(LogLine& line, T& value) {
+    line.stream << std::forward<T>(value);
+    return line;
+}
+
+template<typename T>
 LogLine& operator<<(LogLine& line, T&& value) {
     line.stream << std::forward<T>(value);
     return line;

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -22,7 +22,15 @@ void Sensor::start() {
     if (started || stopped) {
         throw std::runtime_error("Sensor already started or stopped!");
     }
-    this->sensor_thread = std::thread(&Sensor::run, this);
+    this->sensor_thread = Thread(&Sensor::run, this);
+    try {
+        int priority = Thread::getMaxSchedulingPriority(SchedulingPolicy::RT_ROUND_ROBIN) - 1;
+        this->sensor_thread.setSchedulingPolicy(SchedulingPolicy::RT_ROUND_ROBIN, priority);
+    }
+    catch (std::runtime_error& ex) {
+        Log::log(WARNING) << "[" << name << "] While setting the sensor's thread scheduling policy an exception was thrown: " << ex.what();
+        Log::log(WARNING) << "[" << name << "] Are you running as sudo?";
+    }
     this->started = true;
 }
 

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -27,6 +27,7 @@
 #include "utils/Configuration.h"
 #include "Data.h"
 #include "Broker.h"
+#include "concurrent/Thread.h"
 
 /**
  * A class to interface with a sensor. Provides methods
@@ -189,6 +190,6 @@ private:
     std::atomic<bool> started;
     std::atomic<bool> stopped;
 
-    std::thread sensor_thread;
+    Thread sensor_thread;
 
 };

--- a/src/concurrent/Thread.cpp
+++ b/src/concurrent/Thread.cpp
@@ -43,8 +43,7 @@ void Thread::setSchedulingPolicy(SchedulingPolicy policy, int priority) {
     params.sched_priority = priority; // Ignored if policy is not RT Round Robin or FIFO
     int ret = pthread_setschedparam(this->native_handle(), sched_policy, &params);
     if (ret) {
-        std::string error = (ret == EPERM)? "Insufficient privileges" : "Could not set the scheduling policy";
-        throw std::runtime_error(error);
+        throw std::runtime_error(std::strerror(errno));
     }
 }
 
@@ -53,8 +52,7 @@ SchedulingPolicy Thread::getCurrentSchedulingPolicy() {
     sched_param params;
     int ret = pthread_getschedparam(this->native_handle(), &policy, &params);
     if (ret) {
-        std::string error = (ret == EPERM)? "Insufficient privileges" : "Could not get the scheduling policy";
-        throw std::runtime_error(error);
+        throw std::runtime_error(std::strerror(errno));
     }
     return (SchedulingPolicy)policy;
 }
@@ -64,8 +62,7 @@ int Thread::getCurrentPriority() {
     sched_param params;
     int ret = pthread_getschedparam(this->native_handle(), &policy, &params);
     if (ret) {
-        std::string error = (ret == EPERM)? "Insufficient privileges" : "Could not set the scheduling priority";
-        throw std::runtime_error(error);
+        throw std::runtime_error(std::strerror(errno));
     }
     return params.sched_priority;
 }
@@ -86,8 +83,7 @@ SchedulingPolicy this_thread::getCurrentSchedulingPolicy() {
     sched_param params;
     int ret = pthread_getschedparam(me, &policy, &params);
     if (ret) {
-        std::string error = (ret == EPERM)? "Insufficient privileges" : "Could not get the scheduling policy";
-        throw std::runtime_error(error);
+        throw std::runtime_error(std::strerror(errno));
     }
     return (SchedulingPolicy)policy;
 }
@@ -98,8 +94,7 @@ int this_thread::getCurrentPriority() {
     sched_param params;
     int ret = pthread_getschedparam(me, &policy, &params);
     if (ret) {
-        std::string error = (ret == EPERM)? "Insufficient privileges" : "Could not set the scheduling priority";
-        throw std::runtime_error(error);
+        throw std::runtime_error(std::strerror(errno));
     }
     return params.sched_priority;
 }

--- a/src/concurrent/Thread.h
+++ b/src/concurrent/Thread.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <stdexcept>
 #include <thread>
 #include <sched.h>
 #include <pthread.h>
@@ -85,5 +86,25 @@ public:
 private:
 
     static int convertPolicy(SchedulingPolicy policy);
+
+};
+
+/**
+ * This namespace contains methods to manage the executing (current) thread
+ * It "extends" the std::this_thread namespace 
+ */
+namespace this_thread {
+
+    /**
+     * Get the current scheduling policy for the current thread
+     * @returns The policy used by the scheduler for this thread
+     */
+    SchedulingPolicy getCurrentSchedulingPolicy();
+
+    /**
+     * Get the current priority for the current thread
+     * @returns The priority used by the scheduler for this thread
+     */
+    int getCurrentPriority();
 
 };

--- a/src/concurrent/ThreadPool.cpp
+++ b/src/concurrent/ThreadPool.cpp
@@ -20,7 +20,7 @@
 
 void ThreadPool::init_threads() {
     for (int i = 0; i < threads.size(); ++i) {
-       threads[i] = std::thread(&ThreadPool::thread_run, this);
+        threads[i] = Thread(&ThreadPool::thread_run, this);
     }
 }
 
@@ -54,6 +54,18 @@ void ThreadPool::join() {
     for (auto& thread : threads) {
         if (thread.joinable()) {
             thread.join();
+        }
+    }
+}
+
+void ThreadPool::setSchedulingPolicy(SchedulingPolicy policy, int priority) {
+    for (int i = 0; i < threads.size(); ++i) {
+        try {
+           threads[i].setSchedulingPolicy(policy, priority);
+        }
+        catch (const std::runtime_error& ex) {
+            Log::log(WARNING) << "While setting a ThreadPool's thread scheduling policy an exception was thrown: " << ex.what();
+            Log::log(WARNING) << "Are you running as sudo?";
         }
     }
 }

--- a/src/concurrent/ThreadPool.h
+++ b/src/concurrent/ThreadPool.h
@@ -26,9 +26,14 @@
 #include <condition_variable>
 
 #include "ConcurrentQueue.h"
+#include "Thread.h"
+#include "../Log.h"
 
 /**
- * A class to manage a thread pool
+ * A class to create and manage a thread pool
+ * The pool manages a queue of jobs (tasks/functions without inputs nor outputs)
+ * that are executed asynchronously by the thread pool.
+ * This class guarantees that all threads are joined before this class is destructed.
  */
 class ThreadPool {
 
@@ -41,7 +46,7 @@ public:
     ThreadPool() : thread_count(10), 
         jobs_in_execution(0),
         stopped(false),
-        threads(std::vector<std::thread>(10)) {
+        threads(std::vector<Thread>(10)) {
         init_threads();
     }
 
@@ -52,7 +57,7 @@ public:
     explicit ThreadPool(int count) : thread_count(count),
         jobs_in_execution(0),
         stopped(false),
-        threads(std::vector<std::thread>(count)) {
+        threads(std::vector<Thread>(count)) {
         init_threads();
     }
 
@@ -74,6 +79,13 @@ public:
      * Note: all the queued jobs are discarded
      */
     void join();
+
+    /**
+     * Sets the scheduling policy for all the pool's threads
+     * @param policy The SchedulingPolicy that will follow the threads
+     * @param priority The priority for the threads
+     */
+    void setSchedulingPolicy(SchedulingPolicy policy, int priority);
 
     /**
      * Get the number of threads managed by the class
@@ -101,7 +113,7 @@ private:
 
     ConcurrentQueue<std::function<void(void)>> queue;
 
-    std::vector<std::thread> threads;
+    std::vector<Thread> threads;
 
     std::condition_variable new_job;
 


### PR DESCRIPTION
Until now Broker and Sensor used `std::thread` instances. Now they use rt-data's `Thread` instances with the `SchedulingPolicy::RT_ROUND_ROBIN` policy. This way their threads will get more CPU time.

Also, two new methods added to check the scheduling policy and priority of the current thread without having to ask to a `Thread` instance.

Fixes issue #8